### PR TITLE
Fix settings module import for management and WSGI

### DIFF
--- a/backend/settings/__init__.py
+++ b/backend/settings/__init__.py
@@ -1,0 +1,16 @@
+import os
+
+# Default to development settings if DJANGO_SETTINGS_MODULE is not set
+# This allows `backend.settings` to be importable by manage.py, wsgi.py and asgi.py
+if not os.environ.get('DJANGO_SETTINGS_MODULE'):
+    from .dev import *  # noqa: F401,F403
+else:
+    # When DJANGO_SETTINGS_MODULE points to another module like backend.settings.prod
+    module = os.environ['DJANGO_SETTINGS_MODULE']
+    if module != 'backend.settings':
+        _mod = __import__(module, fromlist=['*'])
+        for setting in dir(_mod):
+            if setting.isupper():
+                globals()[setting] = getattr(_mod, setting)
+    else:
+        from .dev import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- add `backend/settings/__init__.py` so `backend.settings` becomes importable

## Testing
- `python -m py_compile backend/settings/__init__.py`
- `DJANGO_SETTINGS_MODULE=backend.settings.dev python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f4f505d748326a79eb0ce2c3e3685